### PR TITLE
misc: prepare for v0.1.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,66 @@
-# RISCV Container
+# RISC-V Container
 
 [![Build rvgnu Docker Image](https://github.com/qiujiandong/riscv-container/actions/workflows/rvgnu.yml/badge.svg)](https://github.com/qiujiandong/riscv-container/actions/workflows/rvgnu.yml)
 
-## Workflow
+This repository hosts Docker images for RISC-V development, aiming to simplify
+CI testing in GitHub Actions. The toolchain is primarily built from the
+[riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain).
+Currently, only the [rvgnu](https://github.com/qiujiandong/riscv-container/pkgs/container/rvgnu)
+image is supported.
 
-How I update the `rvgnu` docker image in this repo?
+## RVGNU
 
-1. Every a period of time, I'll build the tools manually and upload them to
-the release page with the version number.
-2. I'll maintain the default tools' version in `Dockerfile` to keep them
-as latest as posible.
-3. The tags on `main` branch will note github workflow to build the image with
-dedicated version.
+`rvgnu` includes tools built from the [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain).
+
+### Tools Included
+
+The `rvgnu` image tagged as `v0.1.x` is based on the
+[2025.09.28](https://github.com/riscv-collab/riscv-gnu-toolchain/tree/2025.09.28)
+tag of `riscv-gnu-toolchain`.
+
+| Tool | Version |
+|------|---------|
+| GCC newlib toolchain | 15.1.0 |
+| qemu-riscv32/qemu-riscv64 | 10.1.0 |
+
+### Design Philosophy
+
+> Concise and independent from specific hardware.
+
+The GCC `newlib` toolchain is often used in bare-metal environments. Compared
+to `glibc` or `musl`, `newlib` is smaller. However, running on bare-metal
+requires implementing system calls for specific hardware.  
+Linux environments, on the other hand, are hardware-agnostic, making them a
+better choice for CI testing.  
+But is it possible to build with `newlib` GCC and run on Linux? Yes! `libgloss`
+provides default implementations for some system calls, enabling the use of
+`newlib` GCC while running on Linux.
+
+### Building the Tools
+
+To build the tools, check out the desired tag:
+
+```shell
+cd riscv-gnu-toolchain
+git checkout <tag>
+```
+
+Then, follow these steps to build and archive the tools:
+
+```shell
+./configure --prefix=`pwd`/riscv --enable-multilib --enable-strip
+make -j all build-qemu
+tar -cJvf ../prebuilt_tools_$(git describe --tags --exact-match 2>/dev/null).tar.xz riscv
+```
+
+### Workflow Overview
+
+1. Periodically, I manually build the tools and upload them to the
+[release page](https://github.com/qiujiandong/riscv-container/releases/tag/v1.0.0-rc),
+using the corresponding tag from `riscv-gnu-toolchain`.
+2. I update the tool URLs (specifically the tool tags) in the `Dockerfile` to
+ensure they remain up-to-date.
+3. The latest version of `rvgnu` is based on the most recent commit in the
+`main` branch.
+4. If the latest commit in the `main` branch has a tag in the format `v*.*.*`,
+the Docker image will also be tagged with the same version.

--- a/rvgnu/Dockerfile
+++ b/rvgnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-ARG PREBUILT_TOOLS_VERSION=v0.1.1
+ARG PREBUILT_TOOLS_TAG=2025.09.28
 
 LABEL org.opencontainers.image.source=https://github.com/qiujiandong/riscv-container
 LABEL org.opencontainers.image.description="An image with RISC-V GNU GCC newlib toolchain and QEMU"
@@ -26,7 +26,7 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Asia/Shanghai \
 ENV PREBUILT_TOOLS_ROOT=/opt/riscv
 ENV PATH=${PREBUILT_TOOLS_ROOT}/bin:$PATH
 RUN mkdir -p ${PREBUILT_TOOLS_ROOT} && \
-    wget -qO- -L https://github.com/qiujiandong/riscv-container/releases/download/${PREBUILT_TOOLS_VERSION}/prebuilt_tools_${PREBUILT_TOOLS_VERSION}.tar.xz | \
+    wget -qO- -L https://github.com/qiujiandong/riscv-container/releases/download/v1.0.0-rc/prebuilt_tools_${PREBUILT_TOOLS_TAG}.tar.xz | \
     tar -xJvf - -C ${PREBUILT_TOOLS_ROOT} --strip-components=1
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]


### PR DESCRIPTION
- update README
- prebuilt tools is no need to bind with image version, so change to identify prebuilt tools with repo tag of `riscv-gnu-toolchain`